### PR TITLE
Release 0.1.1: `msrv` down to 1.46.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ris-live-rs"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ris-live-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bgp-models = "0.5.0"
 # cli-tool dependencies
 tungstenite="0.16.0"
 url = "2.1.0"
-clap = "3.0.0-beta.5"
+structopt = "0.3"
 
 [[bin]]
 name="ris-live-reader"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ keywords = ["bgp"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata]
+msrv = "1.46.0"
+
 [dependencies]
 
 serde={version="1.0", features=["derive"]}
@@ -21,8 +24,7 @@ serde_json = "1.0.69"
 bgp-models = "0.5.0"
 
 # cli-tool dependencies
-tungstenite="0.16.0"
-url = "2.1.0"
+tungstenite="0.12.0"
 structopt = "0.3"
 
 [[bin]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # select build image
-FROM rust:1.56 as build
+FROM rust:1.46 as build
 
 # create a new empty shell project
 RUN USER=root cargo new --bin ris_live_rs

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ The program `ris-live-reader` will be installed to your `$CARGO_HOME/bin` (e.g. 
 docker run --rm -it bgpkit/ris-live-reader --help
 ```
 
+## Minimum Supported Rust Version (MSRV)
+
+`1.46.0`
+
 ## Built with ❤️ by BGPKIT Team
 
 BGPKIT is a small-team start-up that focuses on building the best tooling for BGP data in Rust. We have 10 years of

--- a/src/reader/main.rs
+++ b/src/reader/main.rs
@@ -1,5 +1,4 @@
 use tungstenite::{connect, Message};
-use url::Url;
 use ris_live_rs::error::ParserRisliveError;
 use ris_live_rs::{compose_subscription_message, parse_ris_live_message};
 use structopt::StructOpt;
@@ -69,7 +68,7 @@ fn main() {
     let url = format!("{}?client={}", RIS_LIVE_URL_BASE, opts.client);
     // connect to RIPE RIS Live websocket server
     let (mut socket, _response) =
-        connect(Url::parse(url.as_str()).unwrap())
+        connect(url.as_str())
             .expect("Can't connect to RIS Live websocket server");
 
     // subscribe to messages from one collector

--- a/src/reader/main.rs
+++ b/src/reader/main.rs
@@ -2,61 +2,61 @@ use tungstenite::{connect, Message};
 use url::Url;
 use ris_live_rs::error::ParserRisliveError;
 use ris_live_rs::{compose_subscription_message, parse_ris_live_message};
-use clap::Parser;
+use structopt::StructOpt;
 
 const RIS_LIVE_URL_BASE: &str = "ws://ris-live.ripe.net/v1/ws/";
 
 /// ris-live-reader is a simple cli tool that can stream BGP data from RIS-Live project with websocket.
-#[derive(Parser)]
-#[clap(version = "0.1.0", author = "Mingwei Zhang <mingwei@bgpkit.com>")]
+#[derive(StructOpt, Debug)]
+#[structopt(name = "ris-live-reader")]
 struct Opts {
 
     /// client name to identify the stream
-    #[clap(long, default_value="ris-live-rs")]
+    #[structopt(long, default_value="ris-live-rs")]
     client: String,
 
     /// Filter by RRC host: e.g. rrc01
-    #[clap(long)]
+    #[structopt(long)]
     host: Option<String>,
 
     /// Only include messages of a given BGP or RIS type: UPDATE, OPEN, NOTIFICATION, KEEPALIVE, or RIS_PEER_STATE
-    #[clap(long)]
+    #[structopt(long)]
     msg_type: Option<String>,
 
     /// Only include messages containing a given key
-    #[clap(long)]
+    #[structopt(long)]
     require: Option<String>,
 
     /// Only include messages sent by the given BGP peer
-    #[clap(long)]
+    #[structopt(long)]
     peer: Option<String>,
 
     /// Filter UPDATE messages by prefixes in announcements or withdrawals
-    #[clap(long)]
+    #[structopt(long)]
     prefix: Option<String>,
 
     /// Match prefixes that are more specific (part of) `prefix`
-    #[clap(long, parse(from_flag = std::ops::Not::not))]
+    #[structopt(long, parse(from_flag = std::ops::Not::not))]
     more_specific: bool,
 
     /// Match prefixes that are less specific (contain) `prefix`
-    #[clap(long)]
+    #[structopt(long)]
     less_specific: bool,
 
     /// ASN or pattern to match against the AS PATH attribute
-    #[clap(long)]
+    #[structopt(long)]
     path: Option<String>,
 
     /// Output as JSON objects
-    #[clap(long)]
+    #[structopt(long)]
     json: bool,
 
     /// Pretty-print JSON output
-    #[clap(long)]
+    #[structopt(long)]
     pretty: bool,
 
     /// Print out raw message without parsing
-    #[clap(long)]
+    #[structopt(long)]
     raw: bool,
 }
 
@@ -64,7 +64,7 @@ struct Opts {
 ///
 /// For more RIS-Live details, check out their documentation at https://ris-live.ripe.net/manual/
 fn main() {
-    let opts: Opts = Opts::parse();
+    let opts: Opts = Opts::from_args();
 
     let url = format!("{}?client={}", RIS_LIVE_URL_BASE, opts.client);
     // connect to RIPE RIS Live websocket server


### PR DESCRIPTION
This release brings down the minimum supported Rust version down to `1.46.0`, allowing edition 2018 users to use this library.