### PR TITLE
Add support for showing withdrawal messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ris-live-rs"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ msrv = "1.46.0"
 [dependencies]
 
 serde={version="1.0", features=["derive"]}
-serde_json = "1.0.69"
-bgp-models = "0.5.0"
+serde_json = "1.0.81"
+bgp-models = "0.7.0"
 
 # cli-tool dependencies
-tungstenite="0.12.0"
+tungstenite="0.17.2"
 structopt = "0.3"
 
 [[bin]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ macro_rules! unwrap_or_return {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn compose_subscription_message(
     host: Option<String>,
     msg_type: Option<String>,
@@ -109,19 +110,19 @@ pub fn compose_subscription_message(
 
     match more_specific {
         true => {
-            options.push(format!("\"moreSpecific\": true"))
+            options.push("\"moreSpecific\": true".to_string())
         }
         false => {
-            options.push(format!("\"moreSpecific\": false"))
+            options.push("\"moreSpecific\": false".to_string())
         }
     }
 
     match less_specific {
         true => {
-            options.push(format!("\"lessSpecific\": true"))
+            options.push("\"lessSpecific\": true".to_string())
         }
         false => {
-            options.push(format!("\"lessSpecific\": false"))
+            options.push("\"lessSpecific\": false".to_string())
         }
     }
 
@@ -164,10 +165,7 @@ pub fn parse_ris_live_message(msg_str: &str) -> Result<Vec<BgpElem>, ParserRisli
                     let peer_asn = Asn::from(unwrap_or_return!(ris_msg.peer_asn.parse::<u32>(), msg_string));
 
                     // parse path
-                    let as_path = match path{
-                        Some(p) => Some(path_to_as_path(p)),
-                        None => None
-                    };
+                    let as_path = path.map(path_to_as_path);
 
                     // parse community
                     let communities: Option<Vec<MetaCommunity>> = match community {
@@ -196,17 +194,11 @@ pub fn parse_ris_live_message(msg_str: &str) -> Result<Vec<BgpElem>, ParserRisli
                         }
                     };
 
-                    // parse med
-                    let bgp_med = match med{
-                        None => {None}
-                        Some(med) => {Some(med)}
-                    };
-
                     // parse aggregator
                     let bgp_aggregator = match aggregator{
                         None => {(None, None)}
                         Some(aggr_str) => {
-                            let parts = aggr_str.split(":").collect::<Vec<&str>>();
+                            let parts = aggr_str.split(':').collect::<Vec<&str>>();
                             if parts.len()!=2 {
                                 return Err(ParserRisliveError::ElemIncorrectAggregator(aggr_str))
                             }
@@ -238,21 +230,21 @@ pub fn parse_ris_live_message(msg_str: &str) -> Result<Vec<BgpElem>, ParserRisli
 
                                 elems.push(
                                     BgpElem{
-                                        timestamp: ris_msg.timestamp.clone(),
+                                        timestamp: ris_msg.timestamp,
                                         elem_type: ElemType::ANNOUNCE,
-                                        peer_ip: peer_ip.clone(),
-                                        peer_asn: peer_asn.clone(),
+                                        peer_ip,
+                                        peer_asn,
                                         prefix: p,
-                                        next_hop: Some(nexthop.clone()),
+                                        next_hop: Some(nexthop),
                                         as_path: as_path.clone(),
                                         origin_asns: None,
-                                        origin: bgp_origin.clone(),
+                                        origin: bgp_origin,
                                         local_pref: None,
-                                        med: bgp_med.clone(),
+                                        med,
                                         communities: communities.clone(),
                                         atomic: None,
-                                        aggr_asn: bgp_aggregator.0.clone(),
-                                        aggr_ip: bgp_aggregator.1.clone(),
+                                        aggr_asn: bgp_aggregator.0,
+                                        aggr_ip: bgp_aggregator.1,
                                     }
                                 );
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ macro_rules! unwrap_or_return {
 
 #[allow(clippy::too_many_arguments)]
 pub fn compose_subscription_message(
-    host: &String,
+    host: &str,
     msg_type: &Option<String>,
     require: &Option<String>,
     peer: &Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ macro_rules! unwrap_or_return {
 
 #[allow(clippy::too_many_arguments)]
 pub fn compose_subscription_message(
-    host: &Option<String>,
+    host: &String,
     msg_type: &Option<String>,
     require: &Option<String>,
     peer: &Option<String>,
@@ -84,7 +84,7 @@ pub fn compose_subscription_message(
 ) -> String {
     let mut options: Vec<String> = vec![];
 
-    if let Some(host) = host {
+    if host.to_lowercase().as_str() != "all" {
         options.push(format!("\"host\": \"{}\"", host))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,14 +73,14 @@ macro_rules! unwrap_or_return {
 
 #[allow(clippy::too_many_arguments)]
 pub fn compose_subscription_message(
-    host: Option<String>,
-    msg_type: Option<String>,
-    require: Option<String>,
-    peer: Option<String>,
-    prefix: Option<String>,
-    path: Option<String>,
-    more_specific: bool,
-    less_specific: bool,
+    host: &Option<String>,
+    msg_type: &Option<String>,
+    require: &Option<String>,
+    peer: &Option<String>,
+    prefix: &Option<String>,
+    path: &Option<String>,
+    more_specific: &bool,
+    less_specific: &bool,
 ) -> String {
     let mut options: Vec<String> = vec![];
 
@@ -301,7 +301,7 @@ mod tests {
     #[test]
     fn test_ris_live_msg() {
         let msg_str = r#"
-        {"type": "ris_message","data":{"timestamp":1636247118.76,"peer":"2001:7f8:24::82","peer_asn":"58299","id":"20-5761-238131559","host":"rrc20","type":"UPDATE","path":[58299,49981,397666],"origin":"igp","announcements":[{"next_hop":"2001:7f8:24::82","prefixes":["2602:fd9e:f00::/40"]},{"next_hop":"fe80::768e:f8ff:fea6:b2c4","prefixes":["2602:fd9e:f00::/40"]}],"raw":"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF005A02000000434001010040020E02030000E3BB0000C33D00061162800E2B00020120200107F8002400000000000000000082FE80000000000000768EF8FFFEA6B2C400282602FD9E0F"}}
+        {"type": "ris_message","data":{"timestamp":1636247118.76,"peer":"2001:7f8:24::82","peer_asn":"58299","id":"20-5761-238131559","host":"rrc20","type":"UPDATE","path":[58299,49981,397666],"origin":"igp","announcements":[{"next_hop":"2001:7f8:24::82","prefixes":["2602:fd9e:f00::/40"]},{"next_hop":"fe80::768e:f8ff:fea6:b2c4","prefixes":["2602:fd9e:f00::/40"], "withdrawals": ["1.1.1.0/24", "8.8.8.0/24"]}],"raw":"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF005A02000000434001010040020E02030000E3BB0000C33D00061162800E2B00020120200107F8002400000000000000000082FE80000000000000768EF8FFFEA6B2C400282602FD9E0F"}}
         "#;
         let msg = parse_ris_live_message(&msg_str).unwrap();
         for elem in msg {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ fn main() {
     }
 }
 ```
-*/
+ */
 
 use std::net::IpAddr;
 use bgp_models::prelude::*;
@@ -247,6 +247,40 @@ pub fn parse_ris_live_message(msg_str: &str) -> Result<Vec<BgpElem>, ParserRisli
                                         aggr_ip: bgp_aggregator.1,
                                     }
                                 );
+                            }
+
+                            if let Some(prefixes) = &announcement.withdrawals {
+                                for prefix in prefixes {
+                                    let p = match prefix.parse::<NetworkPrefix>(){
+                                        Ok(net) => { net }
+                                        Err(_) => {
+                                            if prefix == "eor" {
+                                                return Err(ParserRisliveError::ElemEndOfRibPrefix)
+                                            }
+                                            return Err(ParserRisliveError::ElemIncorrectPrefix(prefix.to_string()))
+                                        }
+                                    };
+                                    elems.push(
+                                        BgpElem{
+                                            timestamp: ris_msg.timestamp,
+                                            elem_type: ElemType::WITHDRAW,
+                                            peer_ip,
+                                            peer_asn,
+                                            prefix: p,
+                                            next_hop: None,
+                                            as_path: None,
+                                            origin_asns: None,
+                                            origin: None,
+                                            local_pref: None,
+                                            med: None,
+                                            communities: None,
+                                            atomic: None,
+                                            aggr_asn: None,
+                                            aggr_ip: None,
+                                        }
+                                    );
+
+                                }
                             }
                         }
                     }

--- a/src/messages/ris_message.rs
+++ b/src/messages/ris_message.rs
@@ -1,5 +1,6 @@
 use bgp_models::bgp::attributes::AsPath;
 use bgp_models::bgp::attributes::AsPathSegment::{AsSequence, AsSet};
+use bgp_models::network::Asn;
 use serde::{Serialize, Deserialize};
 use serde_json::Value;
 
@@ -67,12 +68,14 @@ pub enum PathSeg {
 
 pub fn path_to_as_path(path: Vec<PathSeg>) -> AsPath {
     let mut as_path = AsPath::new();
-    let mut sequence = vec![];
-    let mut set: Option<Vec<u32>> = None;
+    let mut sequence: Vec<Asn> = vec![];
+    let mut set: Option<Vec<Asn>> = None;
     for node in path {
         match node {
-            PathSeg::Asn(asn) => {sequence.push(asn.clone())}
-            PathSeg::AsSet(s) => {set = Some(s.clone())}
+            PathSeg::Asn(s) => {sequence.push(Asn::from(s))}
+            PathSeg::AsSet(s) => {
+                set = Some(s.into_iter().map(|s| {Asn::from(s)}).collect())
+            }
         }
     }
     as_path.segments.push(AsSequence(sequence));

--- a/src/reader/main.rs
+++ b/src/reader/main.rs
@@ -9,6 +9,7 @@ use structopt::StructOpt;
 const RIS_LIVE_URL_BASE: &str = "ws://ris-live.ripe.net/v1/ws/";
 
 /// ris-live-reader is a simple cli tool that can stream BGP data from RIS-Live project with websocket.
+/// Check out https://ris-live.ripe.net/ for more data source information.
 #[derive(StructOpt, Debug)]
 #[structopt(name = "ris-live-reader")]
 struct Opts {
@@ -17,15 +18,15 @@ struct Opts {
     #[structopt(long, default_value="ris-live-rs")]
     client: String,
 
-    /// Filter by RRC host: e.g. rrc01
-    #[structopt(long)]
-    host: Option<String>,
+    /// Filter by RRC host: e.g. rrc01. Use "all" for the firehose.
+    #[structopt(long, default_value="rrc21")]
+    host: String,
 
     /// Only include messages of a given BGP or RIS type: UPDATE, OPEN, NOTIFICATION, KEEPALIVE, or RIS_PEER_STATE
     #[structopt(long)]
     msg_type: Option<String>,
 
-    /// Only include messages of a given BGP update type: announcement (a) or withdrawal (w)
+    /// Only a given BGP update type: announcement (a) or withdrawal (w)
     #[structopt(long)]
     update_type: Option<String>,
 


### PR DESCRIPTION
In this pull request, we added support for showing withdrawal messages coming from RIS live. This should address issue #7.

We also made a number of improvement to the command-line tool:
* added option `update-type` to allow filtering message by announcement or withdrawal
* set default RIS-live host to be `rrc21` to match what they have on official website. this should stop users from accidental tapping into the full firehose (streaming data from all rrcs). user can still opt-in into firehose by specifying the `--host all` argument
* added link to ris-live website to the cli description.

Additionally, we also run `cargo clippy` and applied all suggested improvements.

This PR bumps the crate version to 0.2.0.